### PR TITLE
demo crate not valid identifier

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -145,3 +145,19 @@ fn test_false_start() {
         assert_eq!(x[0], 0);
     }
 }
+
+macro_rules! crate_not_valid_identifier {
+    ($module:ident) => {
+        struct $module;
+    };
+    () => {
+        paste::item! {
+            $crate::crate_not_valid_identifier! { [<Lib env!("CARGO_PKG_NAME")>] }
+        }
+    }
+}
+
+#[test]
+fn test_crate_not_valid_identifier() {
+   crate_not_valid_identifier!();
+}


### PR DESCRIPTION
hi @dtolnay I ran into another issue after moving from mashup to lando. I'll open a separate issue but rather than pointing you through more complex code Ill wanted to whittle this down to a smaller case in a though away pull for testing

in short I'm trying to prefix my own macros with `$crate::` allow for 2018 style macro imports but inside a paste::item! invocation I found that I'm not able to do so because I'll get the following error

```
    = help: message: `"$crate"` is not a valid identifier
```