### PR TITLE
Mark as no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@
 //! #
 //! # fn main() {}
 //! ```
+#![no_std]
 
 extern crate paste_impl;
 extern crate proc_macro_hack;


### PR DESCRIPTION
This allows use in embedded/kernel environments