### PR TITLE
Add continuous integration with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Macros for all your token pasting needs
 =======================================
 
 [![Build Status](https://api.travis-ci.org/dtolnay/paste.svg?branch=master)](https://travis-ci.org/dtolnay/paste)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/dtolnay/paste?branch=master&svg=true)](https://ci.appveyor.com/project/dtolnay/paste/history)
 [![Latest Version](https://img.shields.io/crates/v/paste.svg)](https://crates.io/crates/paste)
 [![Rust Documentation](https://img.shields.io/badge/api-rustdoc-blue.svg)](https://docs.rs/paste)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,8 @@ install:
 build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
-test_script: %tests%
+test_script: 
+    - %tests%
 
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - platform: x86_64                # Name (is not used other than naming things)
       target: x86_64-pc-windows-msvc  # Triple of target platform
       channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
-      test_script: cargo test --target=%target% --verbose
+      tests: "cargo test --target=%target% --verbose"
     - platform: arm64
       target: aarch64-pc-windows-msvc 
       channel: stable
@@ -22,6 +22,8 @@ install:
 
 build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+test_script: %tests%
 
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,12 +26,3 @@ build_script:
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
-
-deploy:
-  - provider: GitHub
-    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
-    auth_token:
-      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
-    prerelease: true
-    on:
-      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,10 @@ environment:
     - platform: x86_64                # Name (is not used other than naming things)
       target: x86_64-pc-windows-msvc  # Triple of target platform
       channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+      test_script: cargo test --target=%target% --verbose
     - platform: arm64
       target: aarch64-pc-windows-msvc 
       channel: stable
-matrix:
-  allow_failures:                     # Allows jobs with these variables to fail
-    - platform: arm64
 
 install:
     - git submodule update --init
@@ -24,10 +22,6 @@ install:
 
 build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
-
-test_script:
-    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
-#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+image: Visual Studio 2017
+
+environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+    - platform: arm64
+      target: aarch64-pc-windows-msvc 
+      channel: stable
+matrix:
+  allow_failures:                     # Allows jobs with these variables to fail
+    - platform: arm64
+
+install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+artifacts:                          
+    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     - platform: x86_64                # Name (is not used other than naming things)
       target: x86_64-pc-windows-msvc  # Triple of target platform
       channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
-      tests: "cargo test --target=%target% --verbose"
+      tests: "test --target=%target% --verbose"
     - platform: arm64
       target: aarch64-pc-windows-msvc 
       channel: stable
@@ -24,7 +24,7 @@ build_script:
     - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
 
 test_script: 
-    - %tests%
+    - cargo %tests%
 
 artifacts:                          
     - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`


### PR DESCRIPTION
Adds continuous integration with AppVeyor for automated Windows builds. Example builds can be found on https://ci.appveyor.com/project/EwoutH/paste/history

For optimal integration with GitHub, AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.

When enabled, AppVeyor publishes the artifacts with each build.