### PR TITLE
Support&test minimum-versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,12 @@ rust:
   - nightly
 
 script: cargo test
+
+matrix:
+  include:
+    - rust: nightly
+      name: Minimal versions
+      before_script:
+        - cargo -Z minimal-versions generate-lockfile
+      script:
+        - cargo check --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ travis-ci = { repository = "dtolnay/paste" }
 
 [dependencies]
 paste-impl = { version = "=0.1.6", path = "impl" }
-proc-macro-hack = "0.5"
+proc-macro-hack = "0.5.9"
 
 [workspace]
 members = ["impl"]


### PR DESCRIPTION
I thought I was testing `-Z minimum-versions` for a crate using paste, [but I wasn't](https://github.com/CAD97/pointer-utils/pull/37). The minimum patch I could find to make `-Z minimum-versions` work is to set paste to use only as old a proc-macro-hack version as used syn:1.0.