### PR TITLE
Add :upper modifier

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -181,6 +181,8 @@ fn paste_segments(span: Span, segments: &[Segment]) -> Result<TokenStream> {
                 };
                 if ident == "lower" {
                     evaluated.push(last.to_lowercase());
+                } else if ident == "upper" {
+                    evaluated.push(last.to_uppercase());
                 } else {
                     return Err(Error::new_spanned(span, "unsupported modifier"));
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -199,3 +199,29 @@ fn test_env_to_lower() {
         let _ = Libpaste;
     }
 }
+
+mod test_to_upper {
+    macro_rules! m {
+        ($id:ident) => {
+            paste::item! {
+                const [<MY_ $id:upper _HERE>]: &str = stringify!([<$id:upper>]);
+            }
+        };
+    }
+
+    m!(Test);
+
+    #[test]
+    fn test_to_upper() {
+        assert_eq!(MY_TEST_HERE, "TEST");
+    }
+}
+
+#[test]
+fn test_env_to_upper() {
+    paste::expr! {
+        const [<LIB env!("CARGO_PKG_NAME"):upper>]: &str = "libpaste";
+
+        let _ = LIBPASTE;
+    }
+}


### PR DESCRIPTION
This adds the :upper modifier, with tests. I wasn't sure how you want to handle the nightly test at `tests/ui/unsupported-modifier.rs` so I just left it. I imagine you'll just want to delete it?

This addresses #13 