### PR TITLE
Preserve macro metavariables not containing a paste

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -305,3 +305,21 @@ fn test_env_to_camel() {
         let _ = LIBPaste;
     }
 }
+
+#[test]
+fn test_doc_expr() {
+    // https://github.com/dtolnay/paste/issues/29
+
+    macro_rules! doc_expr {
+        ($doc:expr) => {
+            paste::item! {
+                #[doc = $doc]
+                pub struct S;
+            }
+        };
+    }
+
+    doc_expr!(stringify!());
+
+    let _: S;
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -306,8 +306,7 @@ fn test_env_to_camel() {
     }
 }
 
-#[test]
-fn test_doc_expr() {
+mod test_doc_expr {
     // https://github.com/dtolnay/paste/issues/29
 
     macro_rules! doc_expr {
@@ -321,5 +320,8 @@ fn test_doc_expr() {
 
     doc_expr!(stringify!());
 
-    let _: S;
+    #[test]
+    fn test_doc_expr() {
+        let _: S;
+    }
 }


### PR DESCRIPTION
Fixes #29.