### PR TITLE
Erase None-delimited groups in more cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.31.0]
+        rust: [nightly, beta, stable, 1.32.0]
+        include:
+          - rust: 1.31.0
+            rustflags: --cfg no_literal_matcher
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
       - run: cargo test
+        env:
+          RUSTFLAGS: ${{matrix.rustflags}}
 
   minimal:
     name: Minimal versions

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -382,6 +382,7 @@ mod test_pat_in_expr_position {
     rav1e_bad!(std::fmt::Error);
 }
 
+#[cfg(not(no_literal_matcher))]
 mod test_x86_feature_literal {
     // work around https://github.com/rust-lang/rust/issues/72726
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -381,3 +381,20 @@ mod test_pat_in_expr_position {
 
     rav1e_bad!(std::fmt::Error);
 }
+
+mod test_x86_feature_literal {
+    // work around https://github.com/rust-lang/rust/issues/72726
+
+    macro_rules! my_is_x86_feature_detected {
+        ($feat:literal) => {
+            paste::item! {
+                #[test]
+                fn test() {
+                    let _ = is_x86_feature_detected!($feat);
+                }
+            }
+        };
+    }
+
+    my_is_x86_feature_detected!("mmx");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -364,3 +364,20 @@ mod test_type_in_path {
         let _ = get_b;
     }
 }
+
+mod test_pat_in_expr_position {
+    // https://github.com/xiph/rav1e/pull/2324/files
+
+    macro_rules! rav1e_bad {
+        ($e:pat) => {
+            paste::item! {
+                #[test]
+                fn test() {
+                    let _ = $e;
+                }
+            }
+        };
+    }
+
+    rav1e_bad!(std::fmt::Error);
+}


### PR DESCRIPTION
Closes #33.

This includes a workaround for use of $:pat as an expr (https://github.com/xiph/rav1e/pull/2324/files) and for $:literal in the argument of is_x86_feature_detected (https://github.com/rust-lang/rust/issues/72726).