### PR TITLE
Raise minimum supported rust version to 1.45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.32.0]
-        include:
-          - rust: 1.31.0
-            rustflags: --cfg no_literal_matcher
+        rust: [nightly, beta, stable, 1.45.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -413,7 +413,6 @@ mod test_pat_in_expr_position {
     rav1e_bad!(std::fmt::Error);
 }
 
-#[cfg(not(no_literal_matcher))]
 mod test_x86_feature_literal {
     // work around https://github.com/rust-lang/rust/issues/72726
 


### PR DESCRIPTION
This will be required in order to drop proc-macro-hack in favor of native #\[proc_macro\]. https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements