### PR TITLE
Drop dep on proc-macro-hack in favor of native #[proc_macro]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [dependencies]
 paste-impl = { version = "=0.1.18", path = "impl" }
-proc-macro-hack = "0.5.9"
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -10,8 +10,5 @@ repository = "https://github.com/dtolnay/paste"
 [lib]
 proc-macro = true
 
-[dependencies]
-proc-macro-hack = "0.5"
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -6,7 +6,6 @@ use crate::error::{Error, Result};
 use proc_macro::{
     token_stream, Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree,
 };
-use proc_macro_hack::proc_macro_hack;
 use std::iter::{self, FromIterator, Peekable};
 use std::panic;
 
@@ -15,7 +14,7 @@ pub fn item(input: TokenStream) -> TokenStream {
     expand_paste(input)
 }
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn expr(input: TokenStream) -> TokenStream {
     TokenStream::from(TokenTree::Group(Group::new(
         Delimiter::Brace,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,7 @@
 
 #![no_std]
 
-use proc_macro_hack::proc_macro_hack;
-
 /// Paste identifiers within a macro invocation that expands to an expression.
-#[proc_macro_hack]
 pub use paste_impl::expr;
 
 /// Paste identifiers within a macro invocation that expands to one or more


### PR DESCRIPTION
https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements