### PR TITLE
Support ident modifiers in doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ fn expand(input: TokenStream, contains_paste: &mut bool) -> Result<TokenStream> 
                     && (lookbehind == Lookbehind::Pound || lookbehind == Lookbehind::PoundBang)
                     && is_pasted_doc(&content)
                 {
-                    let pasted = do_paste_doc(&content, span);
+                    let pasted = do_paste_doc(&content, span)?;
                     let mut group = Group::new(delimiter, pasted);
                     group.set_span(span);
                     expanded.extend(iter::once(TokenTree::Group(group)));

--- a/tests/test_doc.rs
+++ b/tests/test_doc.rs
@@ -42,3 +42,13 @@ fn test_literals() {
     let expected = "int=0x1 bool=true float=0.01";
     assert_eq!(doc, expected);
 }
+
+#[test]
+fn test_case() {
+    let doc = paste! {
+        get_doc!(#[doc = "HTTP " get:upper "!"])
+    };
+
+    let expected = "HTTP GET!";
+    assert_eq!(doc, expected);
+}


### PR DESCRIPTION
Closes #54.

```rust
#[doc = "Define an endpoint with path that allows only `" $method:snake:upper "` HTTP method"]
```