### PR TITLE
Add a doc alias example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ macro_rules! method_new {
     ($ret:ident) => {
         paste! {
             #[doc = "Create a new `" $ret "` object."]
+            // This will generate a doc alias over "Paste_new".
+            #[doc(alias = $ret _new)]
             pub fn new() -> $ret { todo!() }
         }
     };


### PR DESCRIPTION
It took me some time to realize that I could actually do the same for `doc(alias = "...")` so I think this example will be helpful to other people as well. Thanks a lot for this crate!