### PR TITLE
Added test for lower casing corner case + fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
+[dependencies]
+Inflector = {version = "0.11.4"}
+
 [dev-dependencies]
 paste-test-suite = { version = "0", path = "tests/macros" }
 rustversion = "1.0"

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use inflector::cases::snakecase::to_snake_case;
 use proc_macro::{token_stream, Delimiter, Ident, Span, TokenTree};
 use std::iter::Peekable;
 
@@ -181,16 +182,7 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                         evaluated.push(last.to_uppercase());
                     }
                     "snake" => {
-                        let mut acc = String::new();
-                        let mut prev = '_';
-                        for ch in last.chars() {
-                            if ch.is_uppercase() && prev != '_' {
-                                acc.push('_');
-                            }
-                            acc.push(ch);
-                            prev = ch;
-                        }
-                        evaluated.push(acc.to_lowercase());
+                        evaluated.push(to_snake_case(&last));
                     }
                     "camel" => {
                         let mut acc = String::new();

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -138,6 +138,32 @@ mod test_to_snake {
     }
 }
 
+mod test_to_snake_acme {
+    use inflector::cases::screamingsnakecase::to_screaming_snake_case;
+    use inflector::cases::snakecase::to_snake_case;
+    use paste::paste;
+
+    macro_rules! m {
+        ($id:ident) => {
+            paste! {
+                const RAW: &str = stringify!([<$id>]);
+                const LOWER_SNAKE: &str = stringify!([<$id:snake:lower>]);
+                const UPPER_SNAKE: &str = stringify!([<$id:snake:upper>]);
+            }
+        };
+    }
+    m!(ACMECorp);
+
+    #[test]
+    fn test_to_snake_acme() {
+        let lower_snake_inflector: &str = &to_snake_case(RAW);
+        let screaming_snake_inflector: &str = &to_screaming_snake_case(RAW);
+
+        assert_eq!(LOWER_SNAKE, lower_snake_inflector);
+        assert_eq!(UPPER_SNAKE, screaming_snake_inflector);
+    }
+}
+
 mod test_to_camel {
     use paste::paste;
 


### PR DESCRIPTION
Thanks for the really nifty crate! I came across a small issue recently when writing a program that makes heavy use of meta-programming, including of the paste crate.

I have a string of the form `ACMECorp`. I use both `paste` to convert it to lower snake case when it's an identifier, as well as `inflector` when it's a value. `paste` converts the string as `a_c_m_e_corp`, whereas `inflector` converts it to `acme_corp`. To me, the latter solution feels like the more idiomatic way to do this case conversion.

I was able to reproduce this example by writing a test against the `ACMECorp` identifier. I got it to fail, and tried to change the original implementation to match the `inflector` behavior, but the logic turned out to be too complex. And indeed, in the [inflector code](https://binast.github.io/binjs-ref/src/inflector/cases/case/mod.rs.html#123), there is quite a bit more logic dealing with this sort of complexity. So I gave up and added a dependency on `inflector`.

I noticed that you have no other dependencies in this crate, so I don't know to what extent this is okay as far as the main branch is concerned, but this does solve my own problem for the time being. I figured I would share what I have so far, since this is a working solution for a small but surprisingly annoying problem.