### PR TITLE
Add capitalize and decapitalize modifiers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,19 @@
 //!
 //! Use `$var:snake` to convert CamelCase input to snake\_case.
 //! Use `$var:camel` to convert snake\_case to CamelCase.
+//! Use `$var:capitalize` to transform the first character to uppercase.
+//! Use `$var:decapitalize` to transform the first character to lowercase.
 //! These compose, so for example `$var:snake:upper` would give you SCREAMING\_CASE.
 //!
-//! The precise Unicode conversions are as defined by [`str::to_lowercase`] and
-//! [`str::to_uppercase`].
+//! If you want lowerCamelCase, you can use `$var:camel:decapitalize`.
+//!
+//! The precise Unicode conversions are as defined by [`str::to_lowercase`],
+//! [`str::to_uppercase`], [`char::to_lowercase`], and [`char::to_uppercase`].
 //!
 //! [`str::to_lowercase`]: https://doc.rust-lang.org/std/primitive.str.html#method.to_lowercase
 //! [`str::to_uppercase`]: https://doc.rust-lang.org/std/primitive.str.html#method.to_uppercase
+//! [`char::to_lowercase`]: https://doc.rust-lang.org/std/primitive.char.html#method.to_lowercase
+//! [`char::to_uppercase`]: https://doc.rust-lang.org/std/primitive.char.html#method.to_uppercase
 //!
 //! <br>
 //!

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -180,6 +180,12 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                     "upper" => {
                         evaluated.push(last.to_uppercase());
                     }
+                    "capitalize" => {
+                        evaluated.push(transform_first_char(&last, char::to_uppercase));
+                    }
+                    "decapitalize" => {
+                        evaluated.push(transform_first_char(&last, char::to_lowercase));
+                    }
                     "snake" => {
                         let mut acc = String::new();
                         let mut prev = '_';
@@ -230,4 +236,25 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
         pasted.insert(0, '\'');
     }
     Ok(pasted)
+}
+
+// Apply some transformation on the first character of the input string. 
+// The resulting characters replace the first character.
+fn transform_first_char<I>(input: &str, transform: impl Fn(char) -> I) -> String
+where
+    I: Iterator<Item = char>,
+{
+    let mut transformed = String::new();
+    let mut first = true;
+    for c in input.chars() {
+        if first {
+            for c in transform(c) {
+                transformed.push(c);
+            }
+        } else {
+            transformed.push(c);
+        }
+        first = false;
+    }
+    transformed
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -161,6 +161,48 @@ mod test_to_camel {
     }
 }
 
+mod test_capitalize {
+    use paste::paste;
+
+    macro_rules! m {
+        ($id:ident) => {
+            paste! {
+                const CAPITALIZED: &str = stringify!([<$id:capitalize>]);
+                const CAPITALIZED_SNAKE: &str = stringify!([<$id:snake:capitalize>]);
+            }
+        };
+    }
+
+    m!(thisIsButATest);
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(CAPITALIZED, "ThisIsButATest");
+        assert_eq!(CAPITALIZED_SNAKE, "This_is_but_a_test");
+    }
+}
+
+mod test_decapitalize {
+    use paste::paste;
+
+    macro_rules! m {
+        ($id:ident) => {
+            paste! {
+                const DECAPITALIZED: &str = stringify!([<$id:decapitalize>]);
+                const DECAPITALIZED_CAMEL: &str = stringify!([<$id:camel:decapitalize>]);
+            }
+        };
+    }
+
+    m!(This_is_but_a_test);
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(DECAPITALIZED, "this_is_but_a_test");
+        assert_eq!(DECAPITALIZED_CAMEL, "thisIsButATest");
+    }
+}
+
 mod test_doc_expr {
     // https://github.com/dtolnay/paste/issues/29
 


### PR DESCRIPTION
Thanks for the useful crate!

Using #23 as a guide, I implemented `capitalize` and `decapitalize` in order to support `lowerCamelCase`.