### PR TITLE
Add support for hex modifier

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,10 @@ impl Error {
         }
     }
 
+    pub fn new2_owned(begin: Span, end: Span, msg: String) -> Self {
+        Error { begin, end, msg }
+    }
+
     pub fn to_compile_error(&self) -> TokenStream {
         // compile_error! { $msg }
         TokenStream::from_iter(vec![

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -213,6 +213,22 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                         }
                         evaluated.push(acc);
                     }
+                    "hex" => {
+                        // A valid identifier must be prefixed with '_' or an alphabet.
+                        // Using '_' as the prefix so that it can be omitted while converted to camel case.
+                        let mut acc = "_".to_string();
+                        for &byte in last.as_bytes() {
+                            use std::fmt::Write;
+                            if let Err(e) = write!(&mut acc, "{:x}", byte) {
+                                return Err(Error::new2_owned(
+                                    colon.span,
+                                    ident.span(),
+                                    format!("{}", e),
+                                ));
+                            }
+                        }
+                        evaluated.push(acc)
+                    }
                     _ => {
                         return Err(Error::new2(
                             colon.span,

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -177,8 +177,8 @@ mod test_to_hex {
     m!(r#"\Test/"#);
 
     #[test]
-    fn test_to_lower() {
-        assert_eq!(my_5c546573742f_here(0), "5c546573742f");
+    fn test_to_hex() {
+        assert_eq!(my_5c546573742f_here(0), "_5c546573742f");
     }
 }
 

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -165,7 +165,7 @@ mod test_to_hex {
     use paste::paste;
 
     macro_rules! m {
-        ($id:ident) => {
+        ($id:expr) => {
             paste! {
                 fn [<my $id:hex _here>](_arg: u8) -> &'static str {
                     stringify!([<$id:hex>])
@@ -174,11 +174,11 @@ mod test_to_hex {
         };
     }
 
-    m!(Test);
+    m!(r#"\Test/"#);
 
     #[test]
     fn test_to_lower() {
-        assert_eq!(my_54657374_here(0), "_54657374");
+        assert_eq!(my_5c546573742f_here(0), "5c546573742f");
     }
 }
 

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -161,6 +161,27 @@ mod test_to_camel {
     }
 }
 
+mod test_to_hex {
+    use paste::paste;
+
+    macro_rules! m {
+        ($id:ident) => {
+            paste! {
+                fn [<my $id:hex _here>](_arg: u8) -> &'static str {
+                    stringify!([<$id:hex>])
+                }
+            }
+        };
+    }
+
+    m!(Test);
+
+    #[test]
+    fn test_to_lower() {
+        assert_eq!(my_54657374_here(0), "_54657374");
+    }
+}
+
 mod test_doc_expr {
     // https://github.com/dtolnay/paste/issues/29
 


### PR DESCRIPTION
Add `:hex` modifier to convert the string literal to its hex representation. This is helpful when a string literal which is not a valid rust identifier is passed to the micro and used to identify some definition in the macro.