### PR TITLE
Don't confuse :: with beginning of a case conversion

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::segment::{self, Segment};
-use proc_macro::{Delimiter, Group, Span, TokenStream, TokenTree};
+use proc_macro::{Delimiter, Group, Spacing, Span, TokenStream, TokenTree};
 use std::iter;
 use std::mem;
 use std::str::FromStr;
@@ -157,6 +157,8 @@ fn is_stringlike(token: &TokenTree) -> bool {
                 None => false,
             }
         }
-        TokenTree::Punct(punct) => punct.as_char() == '\'' || punct.as_char() == ':',
+        TokenTree::Punct(punct) => {
+            punct.as_char() == '\'' || punct.as_char() == ':' && punct.spacing() == Spacing::Alone
+        }
     }
 }

--- a/tests/test_attr.rs
+++ b/tests/test_attr.rs
@@ -43,3 +43,18 @@ fn test_paste_cfg() {
 
     let _ = new;
 }
+
+#[test]
+fn test_path_in_attr() {
+    macro_rules! m {
+        (#[x = $x:ty]) => {
+            stringify!($x)
+        };
+    }
+
+    let ty = paste! {
+        m!(#[x = foo::Bar])
+    };
+
+    assert_eq!("foo::Bar", ty);
+}


### PR DESCRIPTION
Fixes #70.