### PR TITLE
Reject byte literal and byte string literal inside paste

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,11 @@ fn parse_bracket_as_segments(input: TokenStream, scope: Span) -> Result<Vec<Segm
 
     for segment in &mut segments {
         if let Segment::String(string) = segment {
-            if string.value.contains(&['#', '\\', '.', '+'][..]) {
+            if string.value.contains(&['#', '\\', '.', '+'][..])
+                || string.value.starts_with("b'")
+                || string.value.starts_with("b\"")
+                || string.value.starts_with("br\"")
+            {
                 return Err(Error::new(string.span, "unsupported literal"));
             }
             string.value = string

--- a/tests/ui/unsupported-literal.rs
+++ b/tests/ui/unsupported-literal.rs
@@ -1,7 +1,21 @@
 use paste::paste;
 
 paste! {
-    fn [<1e+100>]() {}
+    fn [<x 1e+100 z>]() {}
+}
+
+paste! {
+    // `xyz` is not correct. `xbyz` is certainly not correct. Maybe `x121z`
+    // would be justifiable but for now don't accept this.
+    fn [<x b'y' z>]() {}
+}
+
+paste! {
+    fn [<x b"y" z>]() {}
+}
+
+paste! {
+    fn [<x br"y" z>]() {}
 }
 
 fn main() {}

--- a/tests/ui/unsupported-literal.stderr
+++ b/tests/ui/unsupported-literal.stderr
@@ -1,5 +1,23 @@
 error: unsupported literal
- --> tests/ui/unsupported-literal.rs:4:10
+ --> tests/ui/unsupported-literal.rs:4:12
   |
-4 |     fn [<1e+100>]() {}
-  |          ^^^^^^
+4 |     fn [<x 1e+100 z>]() {}
+  |            ^^^^^^
+
+error: unsupported literal
+  --> tests/ui/unsupported-literal.rs:10:12
+   |
+10 |     fn [<x b'y' z>]() {}
+   |            ^^^^
+
+error: unsupported literal
+  --> tests/ui/unsupported-literal.rs:14:12
+   |
+14 |     fn [<x b"y" z>]() {}
+   |            ^^^^
+
+error: unsupported literal
+  --> tests/ui/unsupported-literal.rs:18:12
+   |
+18 |     fn [<x br"y" z>]() {}
+   |            ^^^^^


### PR DESCRIPTION
Previously `[<x b'y' z>]` would turn into `xbyz` which is certainly not correct. I believe `xyz` is also not correct here. Maybe `x121z` would be justifiable but for now don't accept this.