### PR TITLE
Strip only surrounding quotes of a literal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,11 +371,15 @@ fn parse_bracket_as_segments(input: TokenStream, scope: Span) -> Result<Vec<Segm
             {
                 return Err(Error::new(string.span, "unsupported literal"));
             }
-            string.value = string
-                .value
-                .replace('"', "")
-                .replace('\'', "")
-                .replace('-', "_");
+            let mut range = 0..string.value.len();
+            if string.value.starts_with("r\"") {
+                range.start += 2;
+                range.end -= 1;
+            } else if string.value.starts_with(&['"', '\''][..]) {
+                range.start += 1;
+                range.end -= 1;
+            }
+            string.value = string.value[range].replace('-', "_");
         }
     }
 

--- a/tests/ui/invalid-ident.rs
+++ b/tests/ui/invalid-ident.rs
@@ -4,4 +4,12 @@ paste! {
     fn [<0 f>]() {}
 }
 
+paste! {
+    fn [<f '"'>]() {}
+}
+
+paste! {
+    fn [<f "'">]() {}
+}
+
 fn main() {}

--- a/tests/ui/invalid-ident.stderr
+++ b/tests/ui/invalid-ident.stderr
@@ -3,3 +3,15 @@ error: `"0f"` is not a valid identifier
   |
 4 |     fn [<0 f>]() {}
   |        ^^^^^^^
+
+error: `"f\""` is not a valid identifier
+ --> tests/ui/invalid-ident.rs:8:8
+  |
+8 |     fn [<f '"'>]() {}
+  |        ^^^^^^^^^
+
+error: `"f'"` is not a valid identifier
+  --> tests/ui/invalid-ident.rs:12:8
+   |
+12 |     fn [<f "'">]() {}
+   |        ^^^^^^^^^


### PR DESCRIPTION
Previously `[<x '"' y>]` and `[<x "'" y>]` would both turn into `xy`, which is not correct. We were stripping out every `'` and `"` character instead of just the ones surrounding the literal.