### PR TITLE
Parse unicode character literals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,6 +364,16 @@ fn parse_bracket_as_segments(input: TokenStream, scope: Span) -> Result<Vec<Segm
 
     for segment in &mut segments {
         if let Segment::String(string) = segment {
+            if string.value.starts_with("'\\u{") {
+                let hex = &string.value[4..string.value.len() - 2];
+                if let Ok(unsigned) = u32::from_str_radix(hex, 16) {
+                    if let Some(ch) = char::from_u32(unsigned) {
+                        string.value.clear();
+                        string.value.push(ch);
+                        continue;
+                    }
+                }
+            }
             if string.value.contains(&['#', '\\', '.', '+'][..])
                 || string.value.starts_with("b'")
                 || string.value.starts_with("b\"")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ use crate::attr::expand_attr;
 use crate::error::{Error, Result};
 use crate::segment::Segment;
 use proc_macro::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
+use std::char;
 use std::iter;
 use std::panic;
 

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -40,6 +40,9 @@ fn test_literals() {
 
     let pasted = paste!([<CONST r"0">]);
     assert_eq!(pasted, CONST0);
+
+    let pasted = paste!([<CONST '\u{30}'>]);
+    assert_eq!(pasted, CONST0);
 }
 
 #[test]


### PR DESCRIPTION
This is especially important because the current proc macro implementation likes making these too much &mdash; https://github.com/rust-lang/rust/pull/95343. In a proc macro `Literal::character('0')` will produce `'\u{30}'` rather than the expected `'0'`.