### PR TITLE
Fix camel num-upper boundary handling

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -201,12 +201,10 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                                     for chu in ch.to_uppercase() {
                                         acc.push(chu);
                                     }
-                                } else if prev.is_uppercase() {
+                                } else {
                                     for chl in ch.to_lowercase() {
                                         acc.push(chl);
                                     }
-                                } else {
-                                    acc.push(ch);
                                 }
                             }
                             prev = ch;

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -128,13 +128,13 @@ mod test_to_snake {
         };
     }
 
-    m!(ThisIsButATest);
+    m!(ThisIsBut1testOf2tests);
 
     #[test]
     fn test_to_snake() {
-        assert_eq!(DEFAULT_SNAKE, "this_is_but_a_test");
-        assert_eq!(LOWER_SNAKE, "this_is_but_a_test");
-        assert_eq!(UPPER_SNAKE, "THIS_IS_BUT_A_TEST");
+        assert_eq!(DEFAULT_SNAKE, "this_is_but1test_of2tests");
+        assert_eq!(LOWER_SNAKE, "this_is_but1test_of2tests");
+        assert_eq!(UPPER_SNAKE, "THIS_IS_BUT1TEST_OF2TESTS");
     }
 }
 
@@ -151,13 +151,13 @@ mod test_to_camel {
         };
     }
 
-    m!(this_is_but_a_test);
+    m!(this_is_but_1Test_of2Tests);
 
     #[test]
     fn test_to_camel() {
-        assert_eq!(DEFAULT_CAMEL, "ThisIsButATest");
-        assert_eq!(LOWER_CAMEL, "thisisbutatest");
-        assert_eq!(UPPER_CAMEL, "THISISBUTATEST");
+        assert_eq!(DEFAULT_CAMEL, "ThisIsBut1testOf2tests");
+        assert_eq!(LOWER_CAMEL, "thisisbut1testof2tests");
+        assert_eq!(UPPER_CAMEL, "THISISBUT1TESTOF2TESTS");
     }
 }
 


### PR DESCRIPTION
Ths PR fixes a problem affecting numbers/uppercase-letter boundaries in identifiers being converted to camel case.

The following else-if case would apply and force the current character to lowercase only if the previous character was uppercase:
https://github.com/dtolnay/paste/blob/c71982e1cc08c8a8fafa17f283ef740a3138e561/src/segment.rs#L204-L208
If the previous character was a number, the above case would not apply and the current character would be pushed unchanged:
https://github.com/dtolnay/paste/blob/c71982e1cc08c8a8fafa17f283ef740a3138e561/src/segment.rs#L208-L210
This would cause an input string like `TMPG_M2HH3` to be incorrectly converted to `TmpgM2Hh3` ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ea4855a2134e31c41d00758b95b3125a)).

The proposed fix is to always force lowercase in the else case, i.e., essentially eliminate the `if prev.is_uppercase()` check.