### PR TITLE
Produce clone of input tokenstream if contains no paste

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,18 @@ use std::panic;
 pub fn paste(input: TokenStream) -> TokenStream {
     let mut contains_paste = false;
     let flatten_single_interpolation = true;
-    match expand(input, &mut contains_paste, flatten_single_interpolation) {
-        Ok(expanded) => expanded,
+    match expand(
+        input.clone(),
+        &mut contains_paste,
+        flatten_single_interpolation,
+    ) {
+        Ok(expanded) => {
+            if contains_paste {
+                expanded
+            } else {
+                input
+            }
+        }
         Err(err) => err.to_compile_error(),
     }
 }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -263,7 +263,9 @@ fn test_top_level_none_delimiter() {
     struct A;
 
     impl A {
-        fn consume_self(self) {}
+        fn consume_self(self) {
+            let _ = self;
+        }
     }
 
     clone!(&A).consume_self();

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -247,3 +247,24 @@ mod test_local_setter {
         assert_eq!(a.val, 42);
     }
 }
+
+// https://github.com/dtolnay/paste/issues/85
+#[test]
+fn test_top_level_none_delimiter() {
+    macro_rules! clone {
+        ($val:expr) => {
+            paste! {
+                $val.clone()
+            }
+        };
+    }
+
+    #[derive(Clone)]
+    struct A;
+
+    impl A {
+        fn consume_self(self) {}
+    }
+
+    clone!(&A).consume_self();
+}


### PR DESCRIPTION
This is a partial mitigation for #85. It _only_ helps if the entire macro input contains no pastes `[<`&hellip;`>]`, such as in the minimal repro in that issue. Every other case involving `Delimiter::None` still remains broken due to https://github.com/rust-lang/rust/issues/67062.