### PR TITLE
trybuild output appears out of date, removed extra line with overwrite

### DIFF
--- a/tests/ui/invalid-ident.stderr
+++ b/tests/ui/invalid-ident.stderr
@@ -6,7 +6,6 @@ error: expected identifier, found `0f`
 5 | | }
   | |_^ expected identifier
   |
-  = help: identifiers cannot start with a number
   = note: this error originates in the macro `paste` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `"f\""` is not a valid identifier


### PR DESCRIPTION
One line change to update based on mismatch output in my terminal.

Just the result of running:

```sh
TRYBUILD=overwrite cargo test
```